### PR TITLE
fix: set_collision_detection_threshold

### DIFF
--- a/toio/cube/api/configuration.py
+++ b/toio/cube/api/configuration.py
@@ -758,7 +758,7 @@ class Configuration(CubeCharacteristic):
         References:
             https://toio.github.io/toio-spec/en/docs/ble_configuration#collision-detection-threshold-settings
         """
-        command = SetHorizontalDetectionThreshold(threshold)
+        command = SetCollisionDetectionThreshold(threshold)
         await self._write(bytes(command))
 
     async def set_double_tap_detection_threshold(self, threshold: int) -> None:


### PR DESCRIPTION
I found bug in toio.py/toio/cube/api/configuration.py line 761.
I think function set_collision_detection_threshold should use SetCollisionDetectionThreshold not SetHorizontalDetectionThreshold.